### PR TITLE
Update to web5/api@0.9.4

### DIFF
--- a/playlist-finder/index.js
+++ b/playlist-finder/index.js
@@ -1,4 +1,4 @@
-import { Web5 } from "https://cdn.jsdelivr.net/npm/@web5/api@0.9.2/dist/browser.mjs";
+import { Web5 } from "https://cdn.jsdelivr.net/npm/@web5/api@0.9.4/dist/browser.mjs";
 
 const loading = document.querySelector("#loading");
 const fanDid = document.querySelector("#fanDid");

--- a/playlist-maker/index.js
+++ b/playlist-maker/index.js
@@ -1,4 +1,4 @@
-import { Web5 } from "https://cdn.jsdelivr.net/npm/@web5/api@0.9.2/dist/browser.mjs";
+import { Web5 } from "https://cdn.jsdelivr.net/npm/@web5/api@0.9.4/dist/browser.mjs";
 import { API_KEY } from "./config.js";
 
 const loading = document.querySelector("#loading");
@@ -12,7 +12,7 @@ const trackList = document.querySelector("#trackList");
 const { web5, did } = await Web5.connect();
 
 if (web5) {
-  // Change loading text on succesful load of web5;
+  // Change loading text on successful load of web5;
   loading.textContent = "Loading tracks...";
   try {
     // Check if protocol exists in user's DWN, otherwise install it


### PR DESCRIPTION
Hi Kirah, I stumbled across your great WWC Open Protocols lab the other day (thank you so much! ❤️).

When I pulled down the repo to play around, I noticed I was getting issues with querying and deleting that weren't happening in the lab, and I could see error responses when deleting referencing what looked like the newish prune feature (`400, SchemaValidatorFailure: /descriptor: must have required property 'prune'"`). Bumping the Web5 API version resolved it, so I thought I'd raise a PR 🙂   Feel free to decline it if this isn't a project you're maintaining, just thought I'd do this in case it's useful.

Before:

https://github.com/kirahsapong/wwc-workshop/assets/32352098/08174acf-af3a-458e-a6db-9d323c8deefd



After:

https://github.com/kirahsapong/wwc-workshop/assets/32352098/d7753eaf-ff9a-47fa-8872-8bfdf3a07024

